### PR TITLE
add Jina.AI web page reader to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ List of cool [TypingMind plugins](https://docs.typingmind.com/plugins).
 - [Forrest Technologies](https://plugins.forresttechnologies.com/) - free and premium
   - Enhanced Reasoning Tool, Vectara Query Plugin. Discord Message Sender, CSV Generator With Download, Fal Video Generator
 - [Memory Plugin](https://www.memoryplugin.com/) - premium
+- [Jina Web Reader](https://github.com/jdblack/typingmind_jina_web_reader) - Uses the Jina.AI page rearder to fetch web pages for the LLM
 - [Plugins shared on TypingMind Discord](https://discord.com/channels/1087527241505853520/1120236521732182056) or [showcase](https://discord.com/channels/1087527241505853520/1140505087148568576) - free
   - [Document Generator](https://cloud.typingmind.com/plugins/p-01JC4MFPZ80KPJ2G0VDQ7Y1SND) - by khoit12
   - [Todoist Integration](https://cloud.typingmind.com/plugins/p-01JC4TCVZYNTY6BB39XBKY8JTC) - by occred


### PR DESCRIPTION
This PR adds a link to a Jina web page reader plugin for TypingMind.