### PR TITLE
Add MCP tool extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ List of open-source [TypingMind extensions](https://docs.typingmind.com/typing-m
 - [Add model search & show model full name](https://gist.github.com/trungdq88/0fae23af49e1c8fb43b36b78f2c5cdcf) - by kenharris
 - [Backup & sync data to AWS S3](https://github.com/itcon-pty-au/typingmind-cloud-backup) - by itcon-pty-au
 - [Export chats to markdown in a zip file](https://gist.github.com/lzilioli/a8298c8622a69768cec9f872c6bb128c) - by idealparadox
+- [Automatically expose MCP tools as plugins](https://github.com/iamjackg/typingmind-mcp-extension) - by iamjackg
 
 ## Plugins
 


### PR DESCRIPTION
I added a link to an extension I developed that allows TypingMind to access MCP tools by automatically creating corresponding plugins. It relies on https://github.com/SecretiveShell/MCP-Bridge to expose MCP tools via a local REST API.