### PR TITLE
Added extension to support persistence of reasoning data for OpenRouter (among others) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ List of open-source [TypingMind extensions](https://docs.typingmind.com/typing-m
 - [Export chats to markdown in a zip file](https://gist.github.com/lzilioli/a8298c8622a69768cec9f872c6bb128c) - by idealparadox
 - [Automatically expose MCP tools as plugins](https://github.com/iamjackg/typingmind-mcp-extension) - by iamjackg
 - [💬 Leave comments on selected text](https://github.com/brzvsk/typingmind-extension-quote) - by brzvsk
+- [Enhance the reliability and reasoning performance of advanced models configured through TypingMind’s custom OpenAI-compatible model settings.] (https://github.com/tejasunku/typingmind-reasoning-support/tree/main)
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ List of open-source [TypingMind extensions](https://docs.typingmind.com/typing-m
 - [Export chats to markdown in a zip file](https://gist.github.com/lzilioli/a8298c8622a69768cec9f872c6bb128c) - by idealparadox
 - [Automatically expose MCP tools as plugins](https://github.com/iamjackg/typingmind-mcp-extension) - by iamjackg
 - [💬 Leave comments on selected text](https://github.com/brzvsk/typingmind-extension-quote) - by brzvsk
-- [Enhance the reliability and reasoning performance of advanced models configured through TypingMind’s custom OpenAI-compatible model settings.] (https://github.com/tejasunku/typingmind-reasoning-support/tree/main)
+- [Enhance the reliability and reasoning performance of advanced models configured through TypingMind’s custom OpenAI-compatible model settings.] (https://github.com/tejasunku/typingmind-reasoning-support/tree/main) by Teja Sunku
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ List of open-source [TypingMind extensions](https://docs.typingmind.com/typing-m
 - [Export chats to markdown in a zip file](https://gist.github.com/lzilioli/a8298c8622a69768cec9f872c6bb128c) - by idealparadox
 - [Automatically expose MCP tools as plugins](https://github.com/iamjackg/typingmind-mcp-extension) - by iamjackg
 - [💬 Leave comments on selected text](https://github.com/brzvsk/typingmind-extension-quote) - by brzvsk
-- [Enhance the reliability and reasoning performance of advanced models configured through TypingMind’s custom OpenAI-compatible model settings.] (https://github.com/tejasunku/typingmind-reasoning-support/tree/main) by Teja Sunku
+- [Enhance the reliability and reasoning performance of advanced models configured through TypingMind’s custom OpenAI-compatible model settings.](https://github.com/tejasunku/typingmind-reasoning-support/tree/main) - by Teja Sunku
 
 ## Plugins
 


### PR DESCRIPTION
Hi! When using models via OpenRouter, I was facing decreased performance from models like OpenAI OSS 120b, Minimax M2, etc., despite getting good performance elsewhere. From [OpenRouter docs](https://openrouter.ai/docs/use-cases/reasoning-tokens#preserving-reasoning-blocks), it turns out that the reasoning_content field needs to persisted across subsequent assistant chat messages. I suspect this may be an issue for using Minimax M2 the official Minimax M2 API as well (see [their API docs](https://platform.minimax.io/docs/guides/text-m2-function-call#openai-sdk)). I couldn't fully tell how fields are preserved for custom OpenAI compatible models due to it being obfuscated by the compiler, so I am unsure if it is an issue elsewhere. Regardless, I wrote this extension because I observed the messages being sent by TypingMind were not adhering to OpenRouter's requirements, and I decided to fix that in order to be able to save money. If you natively support this functionality in TypingMind ever moving forward, please let me know and I can deprecate this extension