### PR TITLE
Add ChatGPT2TypingMind migration tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ List of open-source [TypingMind extensions](https://docs.typingmind.com/typing-m
 - [💬 Leave comments on selected text](https://github.com/brzvsk/typingmind-extension-quote) - by brzvsk
 - [Enhance the reliability and reasoning performance of advanced models configured through TypingMind’s custom OpenAI-compatible model settings.](https://github.com/tejasunku/typingmind-reasoning-support/tree/main) - by Teja Sunku
 
+## Tools & Utilities
+
+- [ChatGPT2TypingMind](https://github.com/K2daOz/chatgpt2typingmind) - by workbench digital. Migrate all ChatGPT chats, projects & images to TypingMind with a Windows GUI app. Auto-detects projects & Custom GPTs, creates nested folder hierarchies, and hosts images via Cloudflare R2 (free). Supports incremental delta-sync.
+
 ## Plugins
 
 List of cool [TypingMind plugins](https://docs.typingmind.com/plugins).


### PR DESCRIPTION
## Summary

Adds **ChatGPT2TypingMind** to a new "Tools & Utilities" section — a Windows GUI app that migrates ChatGPT data to TypingMind.

**Why this is useful for TypingMind users:**

The built-in "Import from OpenAI" dumps all chats into a flat, unsorted list with no folders and no images. This tool preserves:

- **Folder hierarchy** — ChatGPT Projects become nested TypingMind folders
- **All images** — hosted via Cloudflare R2 (free tier), visible in chats, zero performance impact
- **Project & Custom GPT detection** — auto-detected and organized
- **Delta-Sync** — only new chats on subsequent exports

Free version (100 chats) and Pro version available. Fully open source (MIT).

GitHub: https://github.com/K2daOz/chatgpt2typingmind